### PR TITLE
Bugfix for MaskRCNN creating empty log_dir that breaks find_last()

### DIFF
--- a/mrcnn/model.py
+++ b/mrcnn/model.py
@@ -2274,10 +2274,6 @@ class MaskRCNN():
         self.log_dir = os.path.join(self.model_dir, "{}{:%Y%m%dT%H%M}".format(
             self.config.NAME.lower(), now))
 
-        # Create log_dir if not exists
-        if not os.path.exists(self.log_dir):
-            os.makedirs(self.log_dir)
-
         # Path to save after each epoch. Include placeholders that get filled by Keras.
         self.checkpoint_path = os.path.join(self.log_dir, "mask_rcnn_{}_*epoch*.h5".format(
             self.config.NAME.lower()))
@@ -2341,6 +2337,10 @@ class MaskRCNN():
                                          no_augmentation_sources=no_augmentation_sources)
         val_generator = data_generator(val_dataset, self.config, shuffle=True,
                                        batch_size=self.config.BATCH_SIZE)
+
+        # Create log_dir if it does not exist
+        if not os.path.exists(self.log_dir):
+            os.makedirs(self.log_dir)
 
         # Callbacks
         callbacks = [


### PR DESCRIPTION
- Current implementation creates self.log_dir in set_log_dir() function,
  which creates an empty log directory if none exists. This causes
  find_last() to fail after creating a model because it finds this new
  empty directory instead of the previous training directory.
- New implementation moves log_dir creation to the train() function to
  ensure it is only created when it will be used.